### PR TITLE
escaping: replace xml-1.0-illegal characters with question marks

### DIFF
--- a/odf/element.py
+++ b/odf/element.py
@@ -36,6 +36,7 @@ if sys.version_info[0] == 3:
     unichr=chr  # unichr does not exist
 
 _xml11_illegal_ranges = (
+    (0x0, 0x0,),
     (0xd800, 0xdfff,),
     (0xfffe, 0xffff,),
 )

--- a/tests/testunicode.py
+++ b/tests/testunicode.py
@@ -70,11 +70,11 @@ class TestUnicode(unittest.TestCase):
 
     def test_illegaltext(self):
         p = H(outlinelevel=1,text=u"Spot \u001e the")
-        p.addText(u' d\u00a3liberate \ud801 mistakes\U0002fffe')
+        p.addText(u' d\u00a3libe\u0000rate \ud801 mistakes\U0002fffe')
         self.textdoc.text.addElement(p)
         c = self.textdoc.contentxml() # contentxml is supposed to yeld a bytes
         print(c)
-        self.assertContains(c, b'<office:body><office:text><text:h text:outline-level="1">Spot ? the d\xc2\xa3liberate ? mistakes?</text:h></office:text></office:body>')
+        self.assertContains(c, b'<office:body><office:text><text:h text:outline-level="1">Spot ? the d\xc2\xa3libe?rate ? mistakes?</text:h></office:text></office:body>')
         self.assertContains(c, b'xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0"')
         self.assertContains(c, b'<office:automatic-styles/>')
 

--- a/tests/testunicode.py
+++ b/tests/testunicode.py
@@ -63,7 +63,7 @@ class TestUnicode(unittest.TestCase):
         p = H(outlinelevel=1,text=u"Æblegrød")
         p.addText(u' Blåbærgrød')
         self.textdoc.text.addElement(p)
-        c = self.textdoc.contentxml() # contentxml is supposed to yeld a bytes
+        c = self.textdoc.contentxml() # contentxml is supposed to yield a bytes
         self.assertContains(c, b'<office:body><office:text><text:h text:outline-level="1">\xc3\x86blegr\xc3\xb8d Bl\xc3\xa5b\xc3\xa6rgr\xc3\xb8d</text:h></office:text></office:body>')
         self.assertContains(c, b'xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0"')
         self.assertContains(c, b'<office:automatic-styles/>')
@@ -72,8 +72,7 @@ class TestUnicode(unittest.TestCase):
         p = H(outlinelevel=1,text=u"Spot \u001e the")
         p.addText(u' d\u00a3libe\u0000rate \ud801 mistakes\U0002fffe')
         self.textdoc.text.addElement(p)
-        c = self.textdoc.contentxml() # contentxml is supposed to yeld a bytes
-        print(c)
+        c = self.textdoc.contentxml() # contentxml is supposed to yield a bytes
         self.assertContains(c, b'<office:body><office:text><text:h text:outline-level="1">Spot ? the d\xc2\xa3libe?rate ? mistakes?</text:h></office:text></office:body>')
         self.assertContains(c, b'xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0"')
         self.assertContains(c, b'<office:automatic-styles/>')

--- a/tests/testunicode.py
+++ b/tests/testunicode.py
@@ -68,6 +68,16 @@ class TestUnicode(unittest.TestCase):
         self.assertContains(c, b'xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0"')
         self.assertContains(c, b'<office:automatic-styles/>')
 
+    def test_illegaltext(self):
+        p = H(outlinelevel=1,text=u"Spot \u001e the")
+        p.addText(u' d\u00a3liberate \ud801 mistakes\U0002fffe')
+        self.textdoc.text.addElement(p)
+        c = self.textdoc.contentxml() # contentxml is supposed to yeld a bytes
+        print(c)
+        self.assertContains(c, b'<office:body><office:text><text:h text:outline-level="1">Spot ? the d\xc2\xa3liberate ? mistakes?</text:h></office:text></office:body>')
+        self.assertContains(c, b'xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0"')
+        self.assertContains(c, b'<office:automatic-styles/>')
+
 if __name__ == '__main__':
     if sys.version_info[0]==2:
         unittest.main()


### PR DESCRIPTION
This is a strawman PR for https://github.com/eea/odfpy/issues/71

There are a number of open questions over this, but chiefly: is it better to silently swallow illegal characters or replace them with a placeholder. In this implementation I went for the latter, replacing them with question marks. Also if the latter, do we also add the ability to choose the placeholder?

Test included.