### PR TITLE
Use Unicode 'replacement character' for chars not allowed in XML.

### DIFF
--- a/odf/element.py
+++ b/odf/element.py
@@ -86,7 +86,7 @@ def _range_seq_to_re(range_seq):
 _xml_filtered_chars_re = _range_seq_to_re(_xml10_illegal_ranges + _xml_discouraged_ranges)
 
 def _handle_unrepresentable(data):
-    return _xml_filtered_chars_re.sub("?", data)
+    return _xml_filtered_chars_re.sub(u"\ufffd", data)
 
 # The following code is pasted form xml.sax.saxutils
 # Tt makes it possible to run the code without the xml sax package installed

--- a/tests/testunicode.py
+++ b/tests/testunicode.py
@@ -73,7 +73,8 @@ class TestUnicode(unittest.TestCase):
         p.addText(u' d\u00a3libe\u0000rate \ud801 mistakes\U0002fffe')
         self.textdoc.text.addElement(p)
         c = self.textdoc.contentxml() # contentxml is supposed to yield a bytes
-        self.assertContains(c, b'<office:body><office:text><text:h text:outline-level="1">Spot ? the d\xc2\xa3libe?rate ? mistakes?</text:h></office:text></office:body>')
+        # unicode replacement char \UFFFD === \xef\xbf\xbd in UTF-8
+        self.assertContains(c, b'<office:body><office:text><text:h text:outline-level="1">Spot \xef\xbf\xbd the d\xc2\xa3libe\xef\xbf\xbdrate \xef\xbf\xbd mistakes\xef\xbf\xbd</text:h></office:text></office:body>')
         self.assertContains(c, b'xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0"')
         self.assertContains(c, b'<office:automatic-styles/>')
 


### PR DESCRIPTION
Prefer Unicode's "replacement character" which is consistent with the behaviour of `str.encode` in 'replace' mode.

https://github.com/eea/odfpy/issues/71